### PR TITLE
文字数を制限

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -8,7 +8,7 @@
 }
 
 .todo{
-  background:lightgreen;
+  background:rgb(39, 184, 159);
   opacity: 0.8;
   border: 1px solid gray;
   border-radius: 10px;
@@ -17,11 +17,14 @@
 }
 
 .todo:hover{
-  background-color:lightgreen;
   opacity: 1;
   pointer-events: painted;
 }
 
 .delete_todo>form>ul{
   list-style: none;
+}
+
+.warn{
+  color: rgb(193, 93, 62)
 }

--- a/model/addModel.go
+++ b/model/addModel.go
@@ -3,6 +3,7 @@ package model
 import (
 	"fmt"
 	"log"
+	"unicode/utf8"
 )
 
 type NewTodo struct { //追加用
@@ -14,6 +15,9 @@ func AddTodo(newTodo NewTodo) {
 	defer db.Close()
 	fmt.Println(newTodo.Todo)
 	if newTodo.Todo != "" {
+		if utf8.RuneCountInString(newTodo.Todo) > 255 {
+			newTodo.Todo = "error! : max number of charactors is 255"
+		}
 		_, err := db.Exec("insert into todo(todo) values('" + newTodo.Todo + "');")
 		if err != nil {
 			log.Fatalln(err)

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,6 +15,7 @@
         New Todo : <input name="new_todo" type="text" />
         <input type="submit" value="Send" />
       </form>
+      <span class="warn">max number of charactors is 255</span>
     </div>
     <div class="delete_todo">
       <form action="/delete" method="POST">


### PR DESCRIPTION
#1 に関する変更。
文字数を超過した場合は、データベースに代替メッセージが保存されるようになった。